### PR TITLE
fix bug where "Battle" folder for rm2k is not used + more

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
       runs-on: windows-latest
       strategy:
         matrix:
-          go: ['1.15']
+          go: ['1.19']
       name: Go ${{ matrix.go }} on Windows
       env:
         name: windows
@@ -38,7 +38,7 @@ jobs:
       runs-on: macOS-latest
       strategy:
         matrix:
-          go: ['1.15']
+          go: ['1.19']
       name: Go ${{ matrix.go }} on MacOS
       env:
         name: mac
@@ -72,7 +72,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          go: ['1.15']
+          go: ['1.19']
       env:
         name: ubuntu
       steps:

--- a/cmd/rm2kfixwatcher/go.mod
+++ b/cmd/rm2kfixwatcher/go.mod
@@ -1,12 +1,16 @@
 module github.com/silbinarywolf/cmd/rm2kfixwatcher
 
-go 1.15
+go 1.19
 
 require (
-	github.com/karrick/godirwalk v1.16.1
+	github.com/karrick/godirwalk v1.17.0
 	github.com/silbinarywolf/rm2kpng v1.0.0
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 	gopkg.in/fsnotify.v1 v1.4.7
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 )
 
 replace github.com/silbinarywolf/rm2kpng => ../..

--- a/cmd/rm2kfixwatcher/go.sum
+++ b/cmd/rm2kfixwatcher/go.sum
@@ -1,9 +1,9 @@
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
-github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
+github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/cmd/rm2kfixwatcher/rm2kfixwatcher.go
+++ b/cmd/rm2kfixwatcher/rm2kfixwatcher.go
@@ -162,6 +162,7 @@ This tool exists so that users can work in paint tools they're comfortable in wi
 		// Get asset folders
 		assetBaseNameList := []string{
 			// Rm2k
+			"Battle",
 			"Charset",
 			"Chipset",
 			"FaceSet",
@@ -178,7 +179,10 @@ This tool exists so that users can work in paint tools they're comfortable in wi
 			"System2",
 		}
 		for _, baseName := range assetBaseNameList {
-			assetFolderPath := path + string(filepath.Separator) + baseName
+			assetFolderPath, err := filepath.Abs(path + string(filepath.Separator) + baseName)
+			if err != nil {
+				log.Fatalf("Cannot get absolute path: %s", err)
+			}
 			if _, err := os.Stat(assetFolderPath); err != nil {
 				continue
 			}
@@ -194,11 +198,11 @@ This tool exists so that users can work in paint tools they're comfortable in wi
 				Callback: func(osPathname string, de *godirwalk.Dirent) error {
 					if !de.IsRegular() {
 						// ignore directories / symlinks / etc
-						return nil
+						return godirwalk.SkipThis
 					}
 					if filepath.Ext(osPathname) != ".png" {
 						// ignore non-png
-						return nil
+						return godirwalk.SkipThis
 					}
 					filesToUpdate = append(filesToUpdate, osPathname)
 					return nil
@@ -249,7 +253,9 @@ This tool exists so that users can work in paint tools they're comfortable in wi
 		log.Fatalf("Unable to start file watcher: %v", err)
 	}
 	for _, assetDir := range rm2kAssetPathList {
-		watcher.Add(assetDir)
+		if err := watcher.Add(assetDir); err != nil {
+			log.Fatalf(`Unable to watch "%s" folder: %v`, filepath.Base(assetDir), err)
+		}
 	}
 
 	//

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/silbinarywolf/rm2kpng
 
-go 1.15
+go 1.19


### PR DESCRIPTION
**Changelog**

- fix bug where "Battle" folder for rm2k is not used
- Update from Go 1.15 to Go 1.19
- Use absolute paths, this provides better debugging information